### PR TITLE
Fix widget cleanup crash on new ComfyUI frontend

### DIFF
--- a/web/showtext.js
+++ b/web/showtext.js
@@ -8,10 +8,10 @@ app.registerExtension({
     if (nodeData.name === "ShowText") {
       function populate(text) {
         if (this.widgets) {
-          for (let i = 1; i < this.widgets.length; i++) {
-            this.widgets[i].onRemove?.();
+          for (let i = 0; i < this.widgets.length; i++) {
+            this.widgets[i]?.onRemove?.();
           }
-          this.widgets.length = 1;
+          this.widgets.length = 0;
         }
 
         const v = [...text];
@@ -25,8 +25,11 @@ app.registerExtension({
             ["STRING", { multiline: true }],
             app
           ).widget;
-          w.inputEl.readOnly = true;
-          w.inputEl.style.opacity = 0.6;
+          const el = w.inputEl || w.element;
+          if (el) {
+            el.readOnly = true;
+            el.style.opacity = 0.6;
+          }
           w.value = list;
         }
 


### PR DESCRIPTION
## Summary

- Fix `populate()` leaving an `undefined` entry in the widget array, which crashes the new ComfyUI frontend's layout engine (`#arrangeWidgets`) and causes the canvas to stop rendering entirely after node execution
- Add forward-compatible DOM element access (`w.inputEl || w.element`) for newer frontend versions

## Problem

The ShowText node's `text` input uses `forceInput: True`, so the node starts with **zero widgets**. The old cleanup code did `this.widgets.length = 1`, which created `[undefined]` in the array. The new ComfyUI frontend (`comfyui-frontend-package` >= 1.x) iterates all widgets during layout and accesses properties on each — hitting `undefined` throws a `TypeError` that crashes canvas rendering on every frame, making the entire UI blank and unresponsive.

## Changes

- Start widget cleanup loop at index `0` instead of `1` (no pre-existing widgets to preserve)
- Clear widgets to length `0` instead of `1`
- Add `?.` safe-navigation on `onRemove` calls for robustness
- Fall back to `w.element` when `w.inputEl` is not available

## Test plan

- [ ] Load a workflow with a ShowText node connected to any STRING output
- [ ] Execute the workflow — text should display in the node and the UI should remain responsive
- [ ] Reload the page — the saved text should restore correctly via `onConfigure`
- [ ] Verify on both legacy and new (`comfyui-frontend-package` 1.25+) frontends

🤖 Generated with [Claude Code](https://claude.com/claude-code)